### PR TITLE
Change upload GUI from "append" to "replace" existing records

### DIFF
--- a/sample-viewer/src/app/_services/api.service.ts
+++ b/sample-viewer/src/app/_services/api.service.ts
@@ -375,7 +375,7 @@ export class ApiService {
         return {
           next: response['_scroll_id'],
           results: response['hits'],
-          counter: counter+1
+          counter: counter + 1
         };
       }),
       catchError(e => {
@@ -558,33 +558,59 @@ export class ApiService {
     // return (of(results));
   }
 
-// Function to look up IDs and replace
-prepUpload(endpoint:string, uniqueID: string, data:Object[]): Observable<any> {
-  console.log("PREP UPLOAD")
-  const ids = `"${data.map(d => d[uniqueID]).join('","')}"`;
-  const qParams = new HttpParams()
-  .set("q", "__all__")
-  .set("patientID", ids)
-  .set("fields", "alternateIdentifier")
+  // Function to look up IDs and replace
+  prepPatientUpload(endpoint: string, uniqueID: string, data: Object[]): Observable<any> {
+    console.log("PREP UPLOAD")
+    const ids = `"${data.map(d => d[uniqueID]).join('","')}"`;
+    const qParams = new HttpParams()
+      .set("q", "__all__")
+      .set("patientID", ids)
+      .set("fields", "alternateIdentifier")
 
-  return(this.fetchAll(endpoint, qParams).pipe(
-    map(ids => {
-      let duplicateIDs = [];
-      data.forEach(d => {
-        let filtered = ids.filter(id => id.alternateIdentifier.includes(d[uniqueID]));
-        if(filtered.length) {
-        d["_id"] = filtered[0]["_id"];
-        }
+    return (this.fetchAll(endpoint, qParams).pipe(
+      map(ids => {
+        let duplicateIDs = [];
+        data.forEach(d => {
+          let filtered = ids.filter(id => id.alternateIdentifier.includes(d[uniqueID]));
+          if (filtered.length) {
+            d["_id"] = filtered[0]["_id"];
+          }
 
-        if(filtered.length > 1) {
-          duplicateIDs.push(d[uniqueID])
-        }
+          if (filtered.length > 1) {
+            duplicateIDs.push(d[uniqueID])
+          }
+        })
+
+        return (duplicateIDs)
       })
+    ))
+  }
 
-      return(duplicateIDs)
-    })
-  ))
-}
+  prepUpload(endpoint: string, uniqueID: string, data: Object[]): Observable<any> {
+    console.log("PREP UPLOAD")
+    const ids = `"${data.map(d => d[uniqueID]).join('","')}"`;
+    const qParams = new HttpParams()
+      .set("q", `${uniqueID}:${ids}`)
+      .set("fields", uniqueID)
+
+    return (this.fetchAll(endpoint, qParams).pipe(
+      map(ids => {
+        let duplicateIDs = [];
+        data.forEach(uploadRecord => {
+          let filtered = ids.filter(id => id[uniqueID] == uploadRecord[uniqueID]);
+          if (filtered.length) {
+            uploadRecord["_id"] = filtered[0]["_id"];
+          }
+
+          if (filtered.length > 1) {
+            duplicateIDs.push(uploadRecord[uniqueID])
+          }
+        })
+
+        return (duplicateIDs)
+      })
+    ))
+  }
 
   // Function to convert to a json object to be inserted by ES
   jsonify(arr: any[]): string {

--- a/sample-viewer/src/app/add-data/data-upload/data-upload.component.html
+++ b/sample-viewer/src/app/add-data/data-upload/data-upload.component.html
@@ -14,6 +14,7 @@
   <button type="button" mat-raised-button color="primary" (click)="fileInput.click()">Load file</button>
   <!-- Actual workhorse to upload the data on the client side -->
   <input hidden class="d-none" type="file" #fileInput (change)="fileChange($event)" placeholder="Upload file" accept=".csv,.xlsx,.xls,.json" id="file_uploader">
+
   <button style="margin-left: 25px" type="button" mat-raised-button color="warn" [disabled]="!data2upload || uploading" (click)="uploadData()">Upload data</button>
 
 
@@ -21,6 +22,37 @@
 
     <ng-container *ngIf="uploadResponse">
       <h1>{{ uploadResponse }}</h1>
+
+      <!-- data replacement comments -->
+      <ng-container *ngIf="data2upload && !uploading">
+        <ng-container *ngIf="dupes && dupes.length">
+          <h3 class="warning">These patients have multiple entries in the database.</h3>
+          <p>
+            This is probably an error! Delete the duplicates. If you proceed with the upload, the first entry will be overwritten, and the other ones will remain unchanged.
+          </p>
+          <div *ngFor="let item of dupes">
+            {{item}}
+          </div>
+        </ng-container>
+
+        <ng-container *ngIf="replacementIDs && replacementIDs.length">
+          <h3 class="warning">Existing IDs which will be overwritten</h3>
+          <p>
+            These patients already exist in the database. They will be overwritten.
+          </p>
+          <div *ngFor="let id of replacementIDs">
+            {{id}}
+          </div>
+        </ng-container>
+
+        <ng-container *ngIf="newIDs && newIDs.length">
+          <h3>New IDs to add:</h3>
+          <div *ngFor="let id of newIDs">
+            {{id}}
+          </div>
+        </ng-container>
+      </ng-container>
+      
       <mat-progress-bar mode="determinate" [value]="uploadProgress" class="progress-bar"></mat-progress-bar>
       <p class="pct-complete">
         {{ uploadProgress | number:'1.0-0' }}% complete

--- a/sample-viewer/src/app/add-data/data-upload/data-upload.component.html
+++ b/sample-viewer/src/app/add-data/data-upload/data-upload.component.html
@@ -11,9 +11,10 @@
 <!-- <div class="upload-button"> -->
 <div class="upload-button" *ngIf="user.write">
   <!-- Dummy for styling -->
-  <button type="button" mat-raised-button color="primary" (click)="fileInput.click()">Upload data</button>
+  <button type="button" mat-raised-button color="primary" (click)="fileInput.click()">Load file</button>
   <!-- Actual workhorse to upload the data on the client side -->
   <input hidden class="d-none" type="file" #fileInput (change)="fileChange($event)" placeholder="Upload file" accept=".csv,.xlsx,.xls,.json" id="file_uploader">
+  <button style="margin-left: 25px" type="button" mat-raised-button color="warn" [disabled]="!data2upload || uploading" (click)="uploadData()">Upload data</button>
 
 
   <div class="client-responses">

--- a/sample-viewer/src/app/add-data/data-upload/data-upload.component.ts
+++ b/sample-viewer/src/app/add-data/data-upload/data-upload.component.ts
@@ -109,7 +109,7 @@ export class DataUploadComponent implements OnInit {
 
       // listen for the file to be loaded; then save the result.
       reader.onload = (e) => {
-        this.uploadResponse = "File uploaded. Sending data to the database..."
+        this.uploadResponse = "File uploaded; review the new and replacement IDs and then upload"
 
         this.data2upload = this.prepData(reader.result);
 

--- a/sample-viewer/src/app/add-data/data-upload/data-upload.component.ts
+++ b/sample-viewer/src/app/add-data/data-upload/data-upload.component.ts
@@ -136,13 +136,16 @@ export class DataUploadComponent implements OnInit {
         }
 
         this.apiSvc.prepUpload(this.endpoint, uniqueID, this.data2upload).subscribe(dupes => {
-          console.log(dupes)
           dupes.sort((a, b) => a < b ? -1 : 1);
           this.dupes = dupes;
-          this.replacementIDs = this.data2upload.filter(d => d["_id"]).map(d => d["patientID"]);
+          this.replacementIDs = this.data2upload.filter(d => d["_id"]).map(d => d[uniqueID]);
           this.replacementIDs.sort((a, b) => a < b ? -1 : 1);
-          this.newIDs = this.data2upload.filter(d => !d["_id"]).map(d => d["patientID"]);
+          this.newIDs = this.data2upload.filter(d => !d["_id"]).map(d => d[uniqueID]);
           this.newIDs.sort((a, b) => a < b ? -1 : 1);
+          console.log(dupes)
+          console.log(this.replacementIDs)
+          console.log(this.newIDs)
+          console.log(this.data2upload)
         })
 
         // this.apiSvc.putPiecewise(this.endpoint, this.data2upload, uploadSize).subscribe(

--- a/sample-viewer/src/app/add-patients/patient-upload/patient-upload.component.html
+++ b/sample-viewer/src/app/add-patients/patient-upload/patient-upload.component.html
@@ -1,7 +1,7 @@
 <div class="upload-button" *ngIf="user.write">
   <div class="btn-group">
     <!-- Dummy for styling -->
-    <button type="button" mat-raised-button color="primary" (click)="fileInput.click()">Upload patient list</button>
+    <button type="button" mat-raised-button color="primary" (click)="fileInput.click()">Load file</button>
     <!-- Actual workhorse to upload the data on the client side -->
     <input hidden class="d-none" type="file" #fileInput (change)="fileChange($event)" placeholder="Upload file" accept=".csv,.xlsx,.xls,.json" id="file_uploader">
 

--- a/sample-viewer/src/app/add-patients/patient-upload/patient-upload.component.html
+++ b/sample-viewer/src/app/add-patients/patient-upload/patient-upload.component.html
@@ -5,7 +5,7 @@
     <!-- Actual workhorse to upload the data on the client side -->
     <input hidden class="d-none" type="file" #fileInput (change)="fileChange($event)" placeholder="Upload file" accept=".csv,.xlsx,.xls,.json" id="file_uploader">
 
-    <button style="margin-left: 25px" type="button" mat-raised-button color="warn" [disabled]="!data2upload" (click)="uploadData()">Upload data</button>
+    <button style="margin-left: 25px" type="button" mat-raised-button color="warn" [disabled]="!data2upload || uploading" (click)="uploadData()">Upload data</button>
   </div>
 
   <div class="client-responses">

--- a/sample-viewer/src/app/add-patients/patient-upload/patient-upload.component.ts
+++ b/sample-viewer/src/app/add-patients/patient-upload/patient-upload.component.ts
@@ -117,7 +117,7 @@ export class PatientUploadComponent implements OnInit {
         // double check upload size is greater than 0.
         this.uploadSize = this.uploadSize === 0 ? 1 : this.uploadSize;
 
-        this.apiSvc.prepUpload("patient", "patientID", this.data2upload).subscribe(dupes => {
+        this.apiSvc.prepPatientUpload("patient", "patientID", this.data2upload).subscribe(dupes => {
           console.log(dupes)
           dupes.sort((a,b) => a < b ? -1 : 1);
           this.dupes = dupes;

--- a/sample-viewer/src/app/add-patients/patient-upload/patient-upload.component.ts
+++ b/sample-viewer/src/app/add-patients/patient-upload/patient-upload.component.ts
@@ -37,9 +37,7 @@ export class PatientUploadComponent implements OnInit {
 
   constructor(
     private apiSvc: ApiService,
-    private authSvc: AuthService,
-    private patientSvc: GetPatientsService,
-    // private idSvc: CheckIdsService,
+    private authSvc: AuthService
   ) {
     authSvc.userState$.subscribe((user: CvisbUser) => {
       this.user = user;
@@ -127,7 +125,6 @@ export class PatientUploadComponent implements OnInit {
           this.replacementIDs.sort((a,b) => a < b ? -1 : 1);
           this.newIDs = this.data2upload.filter(d => !d["_id"]).map(d => d["patientID"]);
           this.newIDs.sort((a,b) => a < b ? -1 : 1);
-
         })
         // Clear input so can re-upload the same file.
         document.getElementById("file_uploader")['value'] = "";


### PR DESCRIPTION
for /experiment: if an `experimentID` already exists within the API, it will replace that record with the new upload.  New experimentIDs will be appended to the ES index.

for /dataset, /datadownload, /datacatalog: same behavior, only the unique key is `identifier`, not `experimentID`